### PR TITLE
Prevent submit on preview form and enable preview even when form is inactive

### DIFF
--- a/public/modules/forms/admin/views/admin-form.client.view.html
+++ b/public/modules/forms/admin/views/admin-form.client.view.html
@@ -122,7 +122,7 @@
 								</div>
 							</div>
 							<div class="col-md-8 hide-md hide-lg">
-								<iframe id="iframe" ng-if="!!formURL" src="{{trustSrc(formURL + '?isPreview=true')}}"></iframe>
+								<iframe id="iframe" ng-if="!!formURL" src="{{trustSrc(formURL + '/preview')}}"></iframe>
 							</div>
 
 							<div class="col-xs-12 col-sm-offset-4 col-sm-4">

--- a/public/modules/forms/admin/views/admin-form.client.view.html
+++ b/public/modules/forms/admin/views/admin-form.client.view.html
@@ -122,7 +122,7 @@
 								</div>
 							</div>
 							<div class="col-md-8 hide-md hide-lg">
-								<iframe id="iframe" ng-if="!!formURL" src="{{trustSrc(formURL)}}"></iframe>
+								<iframe id="iframe" ng-if="!!formURL" src="{{trustSrc(formURL + '?isPreview=true')}}"></iframe>
 							</div>
 
 							<div class="col-xs-12 col-sm-offset-4 col-sm-4">

--- a/public/modules/forms/base/views/directiveViews/form/submit-form.client.view.html
+++ b/public/modules/forms/base/views/directiveViews/form/submit-form.client.view.html
@@ -77,7 +77,7 @@ ng-style="{'color':button.color}">
 	<button ng-if="!forms.myForm.$invalid"
 		class="Button btn col-sm-2 col-xs-8 focusOn"
 		v-busy="loading" v-busy-label="Please wait" v-pressable
-		ng-disabled="loading || forms.myForm.$invalid"
+		ng-disabled="loading || forms.myForm.$invalid || myform.isPreview"
 		ng-click="submitForm()"
 		on-enter-key="submitForm()"
 		on-enter-key-disabled="loading || forms.myForm.$invalid"

--- a/public/modules/forms/base/views/submit-form.client.view.html
+++ b/public/modules/forms/base/views/submit-form.client.view.html
@@ -1,6 +1,6 @@
 
 
-<section class="public-form" ng-style="{ 'background-color': myform.design.colors.backgroundColor }">
+<section class="public-form" ng-style="{ 'background-color': myform.design.colors.backgroundColor }" ng-hide="!myform.isPreview && !myform.isLive">
 	<submit-form-directive myform="myform"></submit-form-directive>
 </section>
 

--- a/public/modules/forms/config/forms.client.routes.js
+++ b/public/modules/forms/config/forms.client.routes.js
@@ -10,7 +10,7 @@ angular.module('forms').config(['$stateProvider',
 			url: '/forms',
 			templateUrl: 'modules/forms/admin/views/list-forms.client.view.html'
   		}).state('submitForm', {
-			url: '/forms/:formId',
+			url: '/forms/:formId?isPreview',
 			templateUrl: 'modules/forms/base/views/submit-form.client.view.html',
 			data: {
 				hideNav: true
@@ -18,7 +18,9 @@ angular.module('forms').config(['$stateProvider',
 			resolve: {
 				Forms: 'Forms',
 				myForm: function (Forms, $stateParams) {
-					return Forms.get({formId: $stateParams.formId}).$promise;
+					var formToGet = Forms.get({formId: $stateParams.formId}, 
+						function(form) { form.isPreview = $stateParams.isPreview });
+					return formToGet.$promise;
 				}
 			},
 			controller: 'SubmitFormController',

--- a/public/modules/forms/config/forms.client.routes.js
+++ b/public/modules/forms/config/forms.client.routes.js
@@ -10,7 +10,22 @@ angular.module('forms').config(['$stateProvider',
 			url: '/forms',
 			templateUrl: 'modules/forms/admin/views/list-forms.client.view.html'
   		}).state('submitForm', {
-			url: '/forms/:formId?isPreview',
+			url: '/forms/:formId',
+			templateUrl: 'modules/forms/base/views/submit-form.client.view.html',
+			data: {
+				hideNav: true
+			},
+			resolve: {
+				Forms: 'Forms',
+				myForm: function (Forms, $stateParams) {
+					var formToGet = Forms.get({formId: $stateParams.formId})
+					return formToGet.$promise;
+				}
+			},
+			controller: 'SubmitFormController',
+			controllerAs: 'ctrl'
+		}).state('previewForm', {
+			url: '/forms/:formId/preview',
 			templateUrl: 'modules/forms/base/views/submit-form.client.view.html',
 			data: {
 				hideNav: true
@@ -19,7 +34,7 @@ angular.module('forms').config(['$stateProvider',
 				Forms: 'Forms',
 				myForm: function (Forms, $stateParams) {
 					var formToGet = Forms.get({formId: $stateParams.formId}, 
-						function(form) { form.isPreview = $stateParams.isPreview });
+						function(form) { form.isPreview = true });
 					return formToGet.$promise;
 				}
 			},

--- a/public/modules/forms/config/forms.client.routes.js
+++ b/public/modules/forms/config/forms.client.routes.js
@@ -18,7 +18,7 @@ angular.module('forms').config(['$stateProvider',
 			resolve: {
 				Forms: 'Forms',
 				myForm: function (Forms, $stateParams) {
-					var formToGet = Forms.get({formId: $stateParams.formId})
+					var formToGet = Forms.get({formId: $stateParams.formId});
 					return formToGet.$promise;
 				}
 			},


### PR DESCRIPTION
- Fixed bug where inactive form can still be viewed from URL
- Separated preview from actual form, hence enabling the two features: 1) Prevent submit on preview, 2) Preview is still viewable even if form is inactive.