### PR TITLE
Commented out copy code and added 1 to bootstrap md for div

### DIFF
--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -568,7 +568,7 @@
 							<img src="/static/modules/core/img/placeholder.svg">
             </div>
 
-            <div class="col-sm-12 col-md-10 dropzoneContainer">
+            <div class="col-sm-12 col-md-11 dropzoneContainer">
 							<div class="panel-group dropzone" ui-sortable="sortableOptions" ng-model="myform.form_fields">
 
 								<div class="panel panel-default" ng-repeat="field in myform.form_fields" ng-if="!field.deletePreserved" ng-click="openEditModal(field)">
@@ -597,7 +597,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-1 hidden-xs hidden-sm" style="padding:0 5px;">
+<!--             <div class="col-md-1 hidden-xs hidden-sm" style="padding:0 5px;">
                 <div class="panel-group tool-panel text-center">
                     <div class="panel panel-default" ng-repeat="field in myform.form_fields track by field._id" ng-if="!field.deletePreserved">
                         <div class="panel-heading" style="padding: 10px 10px;" ng-click="duplicateField($index)">
@@ -607,7 +607,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </div> -->
 		</div>
 
 		<!-- End Page -->


### PR DESCRIPTION
Bug: When a form field is copied, and an edit is made to one of them, both form fields get the edit (both pointing to the same ID). Furthermore, on the view live page, copied form fields are not able to move on to next field upon pressing Enter.

Quick fix: Visually hide the copy button. 

Justification: Copy field button is not a critical feature, unlike copy form. The workaround for the admin user is to recreate a single field, which is not so laborious.