### PR TITLE
Fixed misaligned views on mobile view

### DIFF
--- a/public/modules/core/css/core.css
+++ b/public/modules/core/css/core.css
@@ -70,11 +70,18 @@ body {
 	border-radius: 0;
 }
 
-@media only screen and (min-width: 760px) {
+.navbar-collapse {
+	border-style:none;
+}
+
+@media only screen and (min-width: 500px) {
 	.navbar .navbar-brand {
 		min-height: 70px;
-		padding: 10px;
 	}
+}
+
+.navbar .navbar-brand {
+	padding: 10px;
 }
 
 .navbar-nav {

--- a/public/modules/core/css/core.css
+++ b/public/modules/core/css/core.css
@@ -69,9 +69,12 @@ body {
   color: white!important;
 	border-radius: 0;
 }
-.navbar .navbar-brand {
-	min-height: 70px;
-	padding: 10px;
+
+@media only screen and (min-width: 760px) {
+	.navbar .navbar-brand {
+		min-height: 70px;
+		padding: 10px;
+	}
 }
 
 .navbar-nav {

--- a/public/modules/users/views/authentication/signin.client.view.html
+++ b/public/modules/users/views/authentication/signin.client.view.html
@@ -21,8 +21,8 @@
 	-->
 	<!-- <h3 class="col-md-12 text-center">Or with your account</h3> -->
 
-	<div class="row valign">
-		<div class="col-md-4 col-md-offset-4 col-xs-12 authen-wrapper">
+	<div class="valign">
+		<div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1 authen-wrapper">
 			<div class="col-md-12 text-center" style="padding-bottom: 50px;">
 				<img src="/static/modules/core/img/logo-full.svg" height="100px">
 			</div>

--- a/public/modules/users/views/authentication/signup.client.view.html
+++ b/public/modules/users/views/authentication/signup.client.view.html
@@ -19,8 +19,8 @@
 	</div> -->
 	<!--<h3 class="col-md-12 text-center">{{ 'SIGNUP_HEADER_TEXT' | translate }}</h3>-->
 
-	<div class="row valign">
-		<div class="col-md-4 col-md-offset-4 col-xs-12 authen-wrapper">
+	<div class="valign">
+		<div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1 authen-wrapper">
 			<div class="col-md-12 text-center vcenter" style="padding-bottom: 50px;">
 				<img src="/static/modules/core/img/logo-full.svg" height="100px">
 			</div>

--- a/public/modules/users/views/password/forgot-password.client.view.html
+++ b/public/modules/users/views/password/forgot-password.client.view.html
@@ -1,6 +1,6 @@
 <section class="auth valign-wrapper" data-ng-controller="PasswordController">
-	<div class="row valign">
-		<div class="col-md-4 col-md-offset-4 col-xs-12 authen-wrapper">
+	<div class="valign">
+		<div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1 authen-wrapper">
 			<div class="col-md-12">
 				<div class="col-md-12 text-center" style="padding-bottom: 50px;">
 					<img src="/static/modules/core/img/logo-full.svg" height="100px">


### PR DESCRIPTION
- Removed min-height for logo on mobile devices so it doesn't come out of the header nav
- Centre login box (for signup, signin and forgot password) screens for all screen sizes
- Removed black border that flickers on mobile view each time user toggles between home page and form

To test it:
In your Chrome browser, toggle to different screen sizes (iPad, iPhone, etc.).