### PR TITLE
Added two copy buttons

### DIFF
--- a/public/modules/forms/admin/views/admin-form.client.view.html
+++ b/public/modules/forms/admin/views/admin-form.client.view.html
@@ -6,14 +6,14 @@
 
 	<div class="page-header" style="padding-bottom: 1em;">
 		<div class="col-xs-12 col-md-12" style="padding-left: 0px !important;">
-			<h1 class="hidden-sm hidden-xs" style="margin-bottom: 0px;" uib-tooltip="{{ myform.title }}">{{ myform.title }}</h1>
-			<h2 class="hidden-md hidden-lg" style="margin-bottom: 10px;" uib-tooltip="{{ myform.title }}">{{ myform.title }}</h2>
+			<h1 class="hidden-xs" style="margin-bottom: 0px;" uib-tooltip="{{ myform.title }}">{{ myform.title }}</h1>
+			<h2 class="hidden-sm hidden-md hidden-lg" style="margin-bottom: 10px;" uib-tooltip="{{ myform.title }}">{{ myform.title }}</h2>
 		</div>
 	</div>
 
 	<div class="row">
 		<div class="col-xs-12">
-			<uib-tabset class="hidden-xs" active="activePill" type="pills" vertical="true">
+			<uib-tabset class="hidden-xs main-tabs" active="activePill" type="pills" vertical="true">
 				<uib-tab index="0">
 					<uib-tab-heading class="ng-scope">{{ 'CONFIGURE_TAB' | translate }}</uib-tab-heading>
 					<configure-form-directive myform="myform" user="user"></configure-form-directive>
@@ -44,7 +44,7 @@
 			-->
 			</uib-tabset>
 
-			<uib-tabset class="hidden-sm hidden-md hidden-lg mobile-tabs" active="activePill" type="pills" vertical="false">
+			<uib-tabset class="hidden-sm hidden-md hidden-lg mobile-tabs main-tabs" active="activePill" type="pills" vertical="false">
 				<uib-tab index="0">
 					<uib-tab-heading><i class="glyphicon glyphicon-wrench"></i></uib-tab-heading>
 					<configure-form-directive myform="myform" user="user"></configure-form-directive>

--- a/public/modules/forms/admin/views/directiveViews/form/share-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/share-form.client.view.html
@@ -15,7 +15,8 @@
 							<input id="copyURL" ng-value="actualFormURL" class="form-control ng-pristine ng-untouched ng-valid">
 						</div>	
 						<div class="col-sm-offset-5 col-sm-2">
-							<button class="btn btn-signup btn-rounded" type="button" ngclipboard data-clipboard-target="#copyURL"><i class="icon-arrow-left icon-white"></i>{{ 'COPY' | translate }}</button>
+							<button class="btn btn-signup btn-rounded hidden-sm hidden-md hidden-lg" type="button" ngclipboard data-clipboard-target=".main-tabs:not(.hidden-xs) #copyURL">{{ 'COPY' | translate }}</button>
+							<button class="btn btn-signup btn-rounded hidden-xs" type="button" ngclipboard data-clipboard-target=".main-tabs:not(.hidden-sm):not(.hidden-md):not(.hidden-lg) #copyURL">{{ 'COPY' | translate }}</button>
 						</div>
 					</div>
 				</uib-tab>
@@ -35,7 +36,8 @@
 								</textarea>
 						</div>
 						<div class="col-sm-offset-5 col-sm-2">
-							<button class="btn btn-signup btn-rounded" type="button" ngclipboard data-clipboard-target="#copyEmbedded">{{ 'COPY' | translate }}</button>
+							<button class="btn btn-signup btn-rounded hidden-sm hidden-md hidden-lg" type="button" ngclipboard data-clipboard-target=".main-tabs:not(.hidden-xs) #copyEmbedded">{{ 'COPY' | translate }}</button>
+							<button class="btn btn-signup btn-rounded hidden-xs" type="button" ngclipboard data-clipboard-target=".main-tabs:not(.hidden-sm):not(.hidden-md):not(.hidden-lg) #copyEmbedded">{{ 'COPY' | translate }}</button>
 						</div>
 					</div>
 				</uib-tab>


### PR DESCRIPTION
Copy was broken due to mobile view story. Because of the duplication of directives in `admin-form.client.view`, `ngclipboard` library was reading the `#copyURL` div from two directive views, and taking the first one.

The solution was to create two copy buttons, and hide one of them according to screen size. 