### PR TITLE
Add selection back

### DIFF
--- a/public/modules/forms/admin/directives/edit-submissions.client.directive.js
+++ b/public/modules/forms/admin/directives/edit-submissions.client.directive.js
@@ -31,10 +31,10 @@ angular.module('forms').directive('editSubmissionsDirective', ['$rootScope', '$h
 					enableVerticalScrollbar: uiGridConstants.scrollbars.ALWAYS,
 					enableHorizontalScrollbar: uiGridConstants.scrollbars.ALWAYS,
 
-					enableRowHeaderSelection: false,
-					enableFullRowSelection: false,
-					enableSelectAll: false,
-					multiSelect: false,
+					enableRowHeaderSelection: true,
+					enableFullRowSelection: true,
+					enableSelectAll: true,
+					multiSelect: true,
 
 					paginationPageSize: DEFAULT_PAGE_SIZE,
 					paginationPageSizes: [ DEFAULT_PAGE_SIZE ],


### PR DESCRIPTION
Selection is added back as sometimes even on first load the submissions are not being loaded.

This is not the optimal solution as selection does nothing now, but is a quick fix with a more elegant solution figured in the future.