### PR TITLE
Added tooltip to upload options, preview header to preview field, zin…

### DIFF
--- a/public/modules/forms/admin/config/i18n/english.js
+++ b/public/modules/forms/admin/config/i18n/english.js
@@ -30,7 +30,7 @@ angular.module('forms').config(['$translateProvider', function ($translateProvid
 		FORM_INACTIVE: 'Form inactive',
 
 		//Edit Field Modal
-		EDIT_FIELD: 'Edit this Field',
+		EDIT_FIELD: 'Edit',
 		SAVE_FIELD: 'Save',
 		ON: 'ON',
 		OFF: 'OFF',

--- a/public/modules/forms/admin/config/i18n/spanish.js
+++ b/public/modules/forms/admin/config/i18n/spanish.js
@@ -26,7 +26,7 @@ angular.module('forms').config(['$translateProvider', function ($translateProvid
 		FORM_INACTIVE: 'Formulario inactivo',
 
 		//Edit Field Modal
-		EDIT_FIELD: 'Editar este campo',
+		EDIT_FIELD: 'Editar',
 		SAVE_FIELD: 'Grabar',
 		ON: 'ON',
 		OFF: 'OFF',

--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -239,7 +239,7 @@
 								</label>
 								<label class="col-md-6 col-xs-6">
 									<input type="radio" data-ng-value="true" ng-model="field.fieldOptionsFromFile"  ng-required="true" />
-									<span>{{ 'ADD_OPTIONS_FILE' | translate }}</span>
+									<span>{{ 'ADD_OPTIONS_FILE' | translate }}&nbsp;<i class="glyphicon glyphicon-question-sign" uib-tooltip=".txt files are supported. Include one option per line. Do not exceed 2000 options, or there will be significant lag." tooltip-trigger="click mouseenter"></i></span> 
 								</label>
 							</div>
 							<div ng-if="!field.fieldOptionsFromFile" class="option-panel">
@@ -405,6 +405,9 @@
 				</div>
 
 				<div class="preview-field-panel col-md-6 hidden-sm hidden-xs container">
+					<div class="modal-header">
+						<h3 class="modal-title preview-header">{{ 'PREVIEW' | translate }}</h3>
+					</div>
 					<form class="public-form">
 						<field-directive field="field" validate="false" class="preview-field">
 						</field-directive>

--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -436,7 +436,7 @@
                             </field-icon-directive>
                         </span>
 
-                        <span class="hidden-xs" style="padding-left:0.3em;">{{type.value}}</span>
+                        <span class="hidden-xs" style="padding-left:0.2em;">{{type.value}}</span>
                     </div>
                 </div>
             </div>

--- a/public/modules/forms/admin/views/directiveViews/form/share-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/share-form.client.view.html
@@ -29,7 +29,7 @@
 							{{ 'COPY_AND_PASTE' | translate }}
 						</h5>
 						<div class="col-sm-12 form-input">
-								<textarea id="copyEmbedded" class="form-control ng-pristine ng-untouched ng-valid" style="min-height:200px; width:100%; color: #30313F;">
+								<textarea id="copyEmbedded" class="form-control ng-pristine ng-untouched ng-valid" style="min-height:200px; width:100%; color: #30313F; resize: vertical;">
 <div style="font-family: Sans-Serif;font-size: 15px;color: #000;opacity: 0.9; padding-top: 5px; padding-bottom: 8px;">If the form below is not loaded, you can also fill it in <a href="{{actualFormURL}}" target=_blank>here</a>.</div>
 
 &lt;!-- {{ 'CHANGE_WIDTH_AND_HEIGHT' | translate }} --&gt;

--- a/public/modules/forms/base/css/base-form.css
+++ b/public/modules/forms/base/css/base-form.css
@@ -169,11 +169,23 @@ section.content > section > section.container {
 /*
 ** Modal CSS Styles
 */
+.ui-datepicker { 
+    /* This is necessary to prevent date picker 
+    from being blocked in preview in Create tab */
+    z-index: 9999 !important; 
+}
 .modal-header {
     padding: 15px;
     border-bottom: 1px solid #e5e5e5;
     font-size: 18px;
     font-weight: normal;
+    margin-bottom: 15px;
+}
+.preview-field-panel .modal-header {
+    margin-right: 20px;
+}
+.preview-field-panel .preview-header {
+    padding-top: 15px;
 }
 .public-form .input-block {
     display: block;


### PR DESCRIPTION
- Added tooltip to upload options to explain format of options file, and max number of options user should include to prevent lag (until infinite loading is done)
- Preview header to make it clearer that the section on the right of edit field is a preview
- Set z-index of datepicker to make it appear on top of edit field popup
- On Create tab, reduced padding-left of field types to ensure dropdown field type does not become two lines on certain screen sizes 
- On Share tab, disabled horizontal resize for Embed URL textarea