### PR TITLE
Bug fixes: Same form field name dropped, Edit "fieldName" not showing when clicking on field already in form

### DIFF
--- a/app/controllers/submissions.server.controller.js
+++ b/app/controllers/submissions.server.controller.js
@@ -39,19 +39,20 @@ exports.delete = function(req, res) {
  */
 exports.create = function(req, res, next) {
 	var form = req.form;
-	var formData = {};
+	var formData = [];
 
 	for (var i = 0; i < req.body.form_fields.length; i++) {
 		var field = req.body.form_fields[i];
-
+		var fieldTuple = [field.title];
 		if (field.fieldType === 'statement' || field.fieldType === 'section') {
 		} else if (field.fieldType === 'yes_no') {
-			formData[field.title] = field.fieldValue == true ? 'Yes' : 'No';
+			fieldTuple.push(field.fieldValue == true ? 'Yes' : 'No');
 		} else if (field.fieldType === 'date') {
-			formData[field.title] = moment(field.fieldValue).tz('Asia/Singapore').format('DD MMM YYYY');
+			fieldTuple.push(moment(field.fieldValue).tz('Asia/Singapore').format('DD MMM YYYY'));
 		} else {
-			formData[field.title] = field.fieldValue;
+			fieldTuple.push(field.fieldValue);
 		}
+		formData.push(fieldTuple);
 	}
 
 	var newSubmission = new Submission({

--- a/app/views/templates/submit-form-email.server.view.html
+++ b/app/views/templates/submit-form-email.server.view.html
@@ -16,10 +16,10 @@
         <td width="40%"><strong>Timestamp</strong></td>
         <td>{{submissionTime}}</td>
       </tr>
-      {% for field, value in formData %}
+      {% for fieldTuple in formData %}
       <tr style="border-top: 1px solid #eee;">
-        <td width="40%"><strong>{{field}}</strong></td>
-        <td>{{value}}</td>
+        <td width="40%"><strong>{{fieldTuple[0]}}</strong></td>
+        <td>{{fieldTuple[1]}}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -40,6 +40,8 @@ angular.module('forms').directive('editFormDirective', ['$rootScope', 'FormField
               var reader = new FileReader();
 
 							$scope.field = curr_field;
+							var fieldTitle = FormFields.types.find(f => f.name === curr_field.fieldType).value;
+							$scope.field.fieldName = fieldTitle;
 							$scope.showLogicJump = false;
 
               if (curr_field.fieldOptionsFromFile) {


### PR DESCRIPTION
- In a form with two fields having the exact same name, only the later field will be sent via email. This is because formData was a dictionary with its key being the field title. Changed formData to be an array of tuples instead.
- Fix Edit "fieldName" not showing when clicking on field already in form